### PR TITLE
Update kroma RPC IP

### DIFF
--- a/kroma/update.sh
+++ b/kroma/update.sh
@@ -8,7 +8,7 @@ ufw disable
 docker-compose -f $HOME/kroma-up/docker-compose.yml --profile validator down
 
 KROMA_VALIDATOR__PRIVATE_KEY=$(cat $HOME/kroma-up/.env | grep KROMA_VALIDATOR__PRIVATE_KEY | awk -F'=' '{print $2}')
-ip_addr=$(curl -s ifconfig.me)
+KROMA_RPC_IP=$(cat $HOME/kroma-up/.env | grep L1_RPC_ENDPOINT | awk -F'[/:]' '{print $4}')
 
 cd $HOME/kroma-up
 
@@ -20,8 +20,8 @@ git pull origin main
 cp .env.sample .env
 
 sed -i "s|KROMA_VALIDATOR__PRIVATE_KEY=.*|KROMA_VALIDATOR__PRIVATE_KEY=$KROMA_VALIDATOR__PRIVATE_KEY|" $HOME/kroma-up/.env
-sed -i "s|KROMA_NODE__L1_RPC_ENDPOINT=.*|KROMA_NODE__L1_RPC_ENDPOINT=http:\/\/$ip_addr:58545|" $HOME/kroma-up/.env
-sed -i "s|KROMA_VALIDATOR__L1_RPC_ENDPOINT=.*|KROMA_VALIDATOR__L1_RPC_ENDPOINT=ws:\/\/$ip_addr:58546|" $HOME/kroma-up/.env
+sed -i "s|KROMA_NODE__L1_RPC_ENDPOINT=.*|KROMA_NODE__L1_RPC_ENDPOINT=http:\/\/$KROMA_RPC_IP:58545|" $HOME/kroma-up/.env
+sed -i "s|KROMA_VALIDATOR__L1_RPC_ENDPOINT=.*|KROMA_VALIDATOR__L1_RPC_ENDPOINT=ws:\/\/$KROMA_RPC_IP:58546|" $HOME/kroma-up/.env
 
 
 sed -i 's/--circuitparams.maxtxs = 0 \\/--circuitparams.maxtxs=0 \\/' $HOME/kroma-up/scripts/entrypoint.sh


### PR DESCRIPTION
It looks it will be better to grep IP from .env for users who doen't setup RPC for each kroma instance.